### PR TITLE
Add tests for Schematron generation.

### DIFF
--- a/ph-sch2xslt-maven-plugin/pom.xml
+++ b/ph-sch2xslt-maven-plugin/pom.xml
@@ -88,6 +88,12 @@
       <artifactId>plexus-build-api</artifactId>
       <version>0.0.7</version>
     </dependency>
+    <dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymock</artifactId>
+      <version>3.4</version>
+      <scope>test</scope>
+    </dependency>    
   </dependencies>
 
   <build>

--- a/ph-sch2xslt-maven-plugin/src/test/java/MavenPluginSchematronTest.java
+++ b/ph-sch2xslt-maven-plugin/src/test/java/MavenPluginSchematronTest.java
@@ -1,0 +1,47 @@
+import java.io.File;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.easymock.EasyMockRule;
+import org.easymock.Mock;
+import org.easymock.TestSubject;
+import org.junit.Rule;
+import org.junit.Test;
+import org.sonatype.plexus.build.incremental.BuildContext;
+
+import com.helger.maven.sch2xslt.Schematron2XSLTMojo;
+
+import static org.easymock.EasyMock.*;
+
+public class MavenPluginSchematronTest
+{
+  @Rule
+  public EasyMockRule mocks = new EasyMockRule(this);
+
+  @Mock
+  private MavenProject project;
+
+  @Mock
+  private BuildContext buildContext;
+
+  @TestSubject
+  private Schematron2XSLTMojo OUT = new Schematron2XSLTMojo();
+
+  @Test
+  public void testMavenPlugin() throws MojoExecutionException,
+      MojoFailureException
+  {
+    expect(project.getBasedir()).andReturn(new File(".")).anyTimes();
+
+    replay(project);
+
+    OUT.setSchematronDirectory(new File("src/test/schematron"));
+    OUT.setSchematronPattern("**\\/*.sch");
+    OUT.setXsltDirectory(new File("target/test/schematron-via-maven-plugin"));
+    OUT.setXsltExtension(".xslt");
+    OUT.execute();
+
+    verify(project);
+  }
+}

--- a/ph-sch2xslt-maven-plugin/src/test/java/XlstSchematronTest.java
+++ b/ph-sch2xslt-maven-plugin/src/test/java/XlstSchematronTest.java
@@ -1,0 +1,69 @@
+import java.io.File;
+
+import net.sf.saxon.Transform;
+
+import org.junit.Test;
+
+import com.helger.commons.io.resource.ClassPathResource;
+
+public class XlstSchematronTest
+{
+
+  private static final String TEST_XSLT_SCHEMATRON = "testXsltSchematron";
+
+  /**
+   * The classpath directory where the Schematron 2 XSLT files reside.
+   */
+  private static final String SCHEMATRON_DIRECTORY_XSLT2 = "schematron/20100414-xslt2/";
+
+  /**
+   * The class path to first XSLT to be applied.
+   */
+  private static final String XSLT2_STEP1 = SCHEMATRON_DIRECTORY_XSLT2
+      + "iso_dsdl_include.xsl";
+
+  /**
+   * The class path to second XSLT to be applied.
+   */
+  private static final String XSLT2_STEP2 = SCHEMATRON_DIRECTORY_XSLT2
+      + "iso_abstract_expand.xsl";
+
+  /**
+   * The class path to third and last XSLT to be applied.
+   */
+  private static final String XSLT2_STEP3 = SCHEMATRON_DIRECTORY_XSLT2
+      + "iso_svrl_for_xslt2.xsl";
+
+  @Test
+  public void testXsltSchematron() throws Exception
+  {    
+    Transform saxonTransform = new Transform();
+
+    String sourcePath = new File("src/test/schematron/check-classifications.sch").getCanonicalPath();
+    String step1Path = (new ClassPathResource(XSLT2_STEP1)).getAsFile().getCanonicalPath();
+    String step2Path = (new ClassPathResource(XSLT2_STEP2)).getAsFile().getCanonicalPath();
+    String step3Path = (new ClassPathResource(XSLT2_STEP3)).getAsFile().getCanonicalPath();
+    String outputPath = new File("target/test/schematron-via-xslt/").getCanonicalPath();
+
+    String[] step1Commands = { 
+        "-xsl:" + step1Path, 
+        "-s:" + sourcePath, 
+        "-o:" + outputPath + "/step1.sch"
+    };
+    String[] step2Commands = { 
+        "-xsl:" + step2Path, 
+        "-s:" + outputPath + "/step1.sch", 
+        "-o:" + outputPath + "/step2.sch"
+    };
+    String[] step3Commands = { 
+        "-xsl:" + step3Path, 
+        "-s:" + outputPath + "/step2.sch", 
+        "-o:" + outputPath + "/check-classifications.xslt"
+    };
+
+    saxonTransform.doTransform(step1Commands, TEST_XSLT_SCHEMATRON);
+    saxonTransform.doTransform(step2Commands, TEST_XSLT_SCHEMATRON);
+    saxonTransform.doTransform(step3Commands, TEST_XSLT_SCHEMATRON);
+  }
+
+}

--- a/ph-sch2xslt-maven-plugin/src/test/schematron/check-classifications.sch
+++ b/ph-sch2xslt-maven-plugin/src/test/schematron/check-classifications.sch
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+
+   <sch:ns uri="http://www.example.org"
+           prefix="ex" />
+
+   <sch:pattern name="Security Classification Policy">
+
+      <sch:p>A Para's classification value cannot be more sensitive 
+         than the Document's classification value.</sch:p> 
+
+      <sch:rule context="ex:Para[@classification='top-secret']">
+
+         <sch:assert test="/ex:Document/@classification='top-secret'">
+             If there is a Para labeled "top-secret" then the Document  
+             should be labeled top-secret
+         </sch:assert>
+
+      </sch:rule>
+
+      <sch:rule context="ex:Para[@classification='secret']">
+
+         <sch:assert test="(/ex:Document/@classification='top-secret') or
+                           (/ex:Document/@classification='secret')">
+             If there is a Para labeled "secret" then the Document  
+             should be labeled either secret or top-secret
+         </sch:assert>
+
+      </sch:rule>
+
+      <sch:rule context="ex:Para[@classification='confidential']">
+
+         <sch:assert test="(/ex:Document/@classification='top-secret') or
+                           (/ex:Document/@classification='secret') or 
+                           (/ex:Document/@classification='confidential')">
+             If there is a Para labeled "confidential" then the Document  
+             should be labeled either confidential, secret or top-secret
+         </sch:assert>
+
+      </sch:rule>
+
+   </sch:pattern>
+
+</sch:schema>


### PR DESCRIPTION
Code for working on https://github.com/phax/ph-schematron/issues/25

Note: None of the test have assert/fails yet.

MavenPluginSchematronTest fails because of no namespace prefixes.

XlstSchematronTest succeeds because it has correct namespace prefixes.

PHSchematronTest is an attempt to write tests closer to the guts of where
the code does the work as the MavenPlugin is too high level.
* testPHSchematronDirectlyOutputViaXMLWriter (fails no namespaces)
* testPHSchematronDirectlyOutputViaTransformer (succeeds)
* testPHSchematronDirectlyOutputViaXMLWriterWithNamespaces (an attempt to
configure with correct options to generate correctly)