### PR TITLE
Pull request for issue 96

### DIFF
--- a/ph-schematron/src/main/java/com/helger/schematron/AbstractSchematronResource.java
+++ b/ph-schematron/src/main/java/com/helger/schematron/AbstractSchematronResource.java
@@ -198,8 +198,10 @@ public abstract class AbstractSchematronResource implements ISchematronResource
   @Nullable
   protected Node getAsNode (@Nonnull final Source aXMLSource) throws Exception
   {
+    DOMReaderSettings settings = internalCreateDOMReaderSettings ();
+    settings.setFeatureValue(EXMLParserFeature.DISALLOW_DOCTYPE_DECL, false);
     // Convert to Node
-    return SchematronResourceHelper.getNodeOfSource (aXMLSource, internalCreateDOMReaderSettings ());
+    return SchematronResourceHelper.getNodeOfSource (aXMLSource, settings);
   }
 
   @Nonnull

--- a/ph-schematron/src/main/java/com/helger/schematron/config/XPathConfig.java
+++ b/ph-schematron/src/main/java/com/helger/schematron/config/XPathConfig.java
@@ -1,0 +1,59 @@
+package com.helger.schematron.config;
+
+import javax.xml.xpath.XPathFactory;
+import javax.xml.xpath.XPathFunctionResolver;
+import javax.xml.xpath.XPathVariableResolver;
+import java.util.Objects;
+
+public class XPathConfig {
+
+    private final XPathFactory xPathFactory;
+
+    private final XPathVariableResolver xPathVariableResolver;
+
+    private final XPathFunctionResolver xPathFunctionResolver;
+
+    public XPathConfig(XPathFactory xPathFactory, XPathVariableResolver xPathVariableResolver,
+                       XPathFunctionResolver xPathFunctionResolver) {
+        this.xPathFactory = xPathFactory;
+        this.xPathVariableResolver = xPathVariableResolver;
+        this.xPathFunctionResolver = xPathFunctionResolver;
+    }
+
+    public XPathFactory getXPathFactory() {
+        return xPathFactory;
+    }
+
+    public XPathVariableResolver getXPathVariableResolver() {
+        return xPathVariableResolver;
+    }
+
+    public XPathFunctionResolver getXPathFunctionResolver() {
+        return xPathFunctionResolver;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof XPathConfig)) return false;
+        XPathConfig that = (XPathConfig) o;
+        return xPathFactory.equals(that.xPathFactory) &&
+                Objects.equals(xPathVariableResolver, that.xPathVariableResolver) &&
+                Objects.equals(xPathFunctionResolver, that.xPathFunctionResolver);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(xPathFactory, xPathVariableResolver, xPathFunctionResolver);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("XPathConfig{");
+        sb.append("xPathFactory=").append(xPathFactory);
+        sb.append(", xPathVariableResolver=").append(xPathVariableResolver);
+        sb.append(", xPathFunctionResolver=").append(xPathFunctionResolver);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/ph-schematron/src/main/java/com/helger/schematron/config/XPathConfig.java
+++ b/ph-schematron/src/main/java/com/helger/schematron/config/XPathConfig.java
@@ -4,6 +4,20 @@ import javax.xml.xpath.XPathFactory;
 import javax.xml.xpath.XPathFunctionResolver;
 import javax.xml.xpath.XPathVariableResolver;
 
+/**
+ * XPath configuration to use.
+ * <p>
+ * This is a counter-measure against <a href="https://github.com/phax/ph-schematron/issues/96">#96</a>:
+ * When using saxon-HE, you have stripped down XPath support (no XPath higher order functions according to the
+ * <a href="https://www.saxonica.com/html/products/feature-matrix-9-9.html">saxon feature matrix</a>).
+ * In this case, you perhaps want to use a different <emph>XPath implementation</emph> (most commonly the XPath
+ * implementation shipped with Java).
+ * </p>
+ *
+ * @see com.helger.schematron.pure.SchematronResourcePure
+ * @see com.helger.schematron.pure.bound.xpath.PSXPathBoundSchema
+ * @see com.helger.schematron.pure.bound.PSBoundSchemaCacheKey
+ */
 public interface XPathConfig {
 
     XPathFactory getXPathFactory();

--- a/ph-schematron/src/main/java/com/helger/schematron/config/XPathConfig.java
+++ b/ph-schematron/src/main/java/com/helger/schematron/config/XPathConfig.java
@@ -3,57 +3,12 @@ package com.helger.schematron.config;
 import javax.xml.xpath.XPathFactory;
 import javax.xml.xpath.XPathFunctionResolver;
 import javax.xml.xpath.XPathVariableResolver;
-import java.util.Objects;
 
-public class XPathConfig {
+public interface XPathConfig {
 
-    private final XPathFactory xPathFactory;
+    XPathFactory getXPathFactory();
 
-    private final XPathVariableResolver xPathVariableResolver;
+    XPathVariableResolver getXPathVariableResolver();
 
-    private final XPathFunctionResolver xPathFunctionResolver;
-
-    public XPathConfig(XPathFactory xPathFactory, XPathVariableResolver xPathVariableResolver,
-                       XPathFunctionResolver xPathFunctionResolver) {
-        this.xPathFactory = xPathFactory;
-        this.xPathVariableResolver = xPathVariableResolver;
-        this.xPathFunctionResolver = xPathFunctionResolver;
-    }
-
-    public XPathFactory getXPathFactory() {
-        return xPathFactory;
-    }
-
-    public XPathVariableResolver getXPathVariableResolver() {
-        return xPathVariableResolver;
-    }
-
-    public XPathFunctionResolver getXPathFunctionResolver() {
-        return xPathFunctionResolver;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof XPathConfig)) return false;
-        XPathConfig that = (XPathConfig) o;
-        return xPathFactory.equals(that.xPathFactory) &&
-                Objects.equals(xPathVariableResolver, that.xPathVariableResolver) &&
-                Objects.equals(xPathFunctionResolver, that.xPathFunctionResolver);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(xPathFactory, xPathVariableResolver, xPathFunctionResolver);
-    }
-
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("XPathConfig{");
-        sb.append("xPathFactory=").append(xPathFactory);
-        sb.append(", xPathVariableResolver=").append(xPathVariableResolver);
-        sb.append(", xPathFunctionResolver=").append(xPathFunctionResolver);
-        sb.append('}');
-        return sb.toString();
-    }
+    XPathFunctionResolver getXPathFunctionResolver();
 }

--- a/ph-schematron/src/main/java/com/helger/schematron/config/XPathConfigBuilder.java
+++ b/ph-schematron/src/main/java/com/helger/schematron/config/XPathConfigBuilder.java
@@ -49,24 +49,25 @@ public class XPathConfigBuilder {
     }
 
     public XPathConfig build() throws XPathFactoryConfigurationException {
-        try {
-            /*
-            XPathFactory aXPathFactory = XPathFactory.newInstance (XPathFactory.DEFAULT_OBJECT_MODEL_URI,
-                    "net.sf.saxon.xpath.XPathFactoryImpl",
-                    ClassLoaderHelper.getContextClassLoader ());
-                    */
-            XPathFactory aXPathFactory = xPathFactoryClass.getConstructor(EMPTY_CLASS_ARRAY)
-                    .newInstance(EMPTY_OBJECT_ARRAY);
-            XPathConfig result = new XPathConfigImpl(aXPathFactory, xPathVariableResolver, xPathFunctionResolver);
-            return result;
-        } catch (InstantiationException e) {
-            throw new XPathFactoryConfigurationException(e);
-        } catch (IllegalAccessException e) {
-            throw new XPathFactoryConfigurationException(e);
-        } catch (InvocationTargetException e) {
-            throw new XPathFactoryConfigurationException(e.getCause());
-        } catch (NoSuchMethodException e) {
-            throw new XPathFactoryConfigurationException(e);
+        XPathFactory aXPathFactory = null;
+        if (xPathFactoryClass != null) {
+            try {
+                aXPathFactory = xPathFactoryClass.getConstructor(EMPTY_CLASS_ARRAY)
+                        .newInstance(EMPTY_OBJECT_ARRAY);
+            } catch (InstantiationException e) {
+                throw new XPathFactoryConfigurationException(e);
+            } catch (IllegalAccessException e) {
+                throw new XPathFactoryConfigurationException(e);
+            } catch (InvocationTargetException e) {
+                throw new XPathFactoryConfigurationException(e.getCause());
+            } catch (NoSuchMethodException e) {
+                throw new XPathFactoryConfigurationException(e);
+            }
+        } else {
+            // DEFAULT as fallback
+            aXPathFactory = XPathConfigs.SAXON_FIRST;
         }
+        XPathConfig result = new XPathConfigImpl(aXPathFactory, xPathVariableResolver, xPathFunctionResolver);
+        return result;
     }
 }

--- a/ph-schematron/src/main/java/com/helger/schematron/config/XPathConfigBuilder.java
+++ b/ph-schematron/src/main/java/com/helger/schematron/config/XPathConfigBuilder.java
@@ -1,0 +1,67 @@
+package com.helger.schematron.config;
+
+import javax.xml.xpath.XPathFactory;
+import javax.xml.xpath.XPathFactoryConfigurationException;
+import javax.xml.xpath.XPathFunctionResolver;
+import javax.xml.xpath.XPathVariableResolver;
+import java.lang.reflect.InvocationTargetException;
+
+public class XPathConfigBuilder {
+
+    private static final Class<?>[] EMPTY_CLASS_ARRAY = new Class<?>[0];
+
+    private static final Object[] EMPTY_OBJECT_ARRAY = new Object[0];
+
+    private Class<? extends XPathFactory> xPathFactoryClass;
+
+    private XPathVariableResolver xPathVariableResolver;
+
+    private XPathFunctionResolver xPathFunctionResolver;
+
+    public XPathConfigBuilder() {
+    }
+
+    public Class<? extends XPathFactory> getxPathFactoryClass() {
+        return xPathFactoryClass;
+    }
+
+    public XPathVariableResolver getxPathVariableResolver() {
+        return xPathVariableResolver;
+    }
+
+    public XPathFunctionResolver getxPathFunctionResolver() {
+        return xPathFunctionResolver;
+    }
+
+    public XPathConfigBuilder setXPathFactoryClass(Class<? extends XPathFactory> xPathFactoryClass) {
+        this.xPathFactoryClass = xPathFactoryClass;
+        return this;
+    }
+
+    public XPathConfigBuilder setXPathVariableResolver(XPathVariableResolver xPathVariableResolver) {
+        this.xPathVariableResolver = xPathVariableResolver;
+        return this;
+    }
+
+    public XPathConfigBuilder setXPathFunctionResolver(XPathFunctionResolver xPathFunctionResolver) {
+        this.xPathFunctionResolver = xPathFunctionResolver;
+        return this;
+    }
+
+    public XPathConfig build() throws XPathFactoryConfigurationException {
+        try {
+            XPathFactory xPathFactory = xPathFactoryClass.getConstructor(EMPTY_CLASS_ARRAY)
+                    .newInstance(EMPTY_OBJECT_ARRAY);
+            XPathConfig result = new XPathConfig(xPathFactory, xPathVariableResolver, xPathFunctionResolver);
+            return result;
+        } catch (InstantiationException e) {
+            throw new XPathFactoryConfigurationException(e);
+        } catch (IllegalAccessException e) {
+            throw new XPathFactoryConfigurationException(e);
+        } catch (InvocationTargetException e) {
+            throw new XPathFactoryConfigurationException(e.getCause());
+        } catch (NoSuchMethodException e) {
+            throw new XPathFactoryConfigurationException(e);
+        }
+    }
+}

--- a/ph-schematron/src/main/java/com/helger/schematron/config/XPathConfigBuilder.java
+++ b/ph-schematron/src/main/java/com/helger/schematron/config/XPathConfigBuilder.java
@@ -1,5 +1,7 @@
 package com.helger.schematron.config;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.xml.xpath.XPathFactory;
 import javax.xml.xpath.XPathFactoryConfigurationException;
 import javax.xml.xpath.XPathFunctionResolver;
@@ -33,17 +35,17 @@ public class XPathConfigBuilder {
         return xPathFunctionResolver;
     }
 
-    public XPathConfigBuilder setXPathFactoryClass(Class<? extends XPathFactory> xPathFactoryClass) {
+    public XPathConfigBuilder setXPathFactoryClass(@Nonnull Class<? extends XPathFactory> xPathFactoryClass) {
         this.xPathFactoryClass = xPathFactoryClass;
         return this;
     }
 
-    public XPathConfigBuilder setXPathVariableResolver(XPathVariableResolver xPathVariableResolver) {
+    public XPathConfigBuilder setXPathVariableResolver(@Nullable XPathVariableResolver xPathVariableResolver) {
         this.xPathVariableResolver = xPathVariableResolver;
         return this;
     }
 
-    public XPathConfigBuilder setXPathFunctionResolver(XPathFunctionResolver xPathFunctionResolver) {
+    public XPathConfigBuilder setXPathFunctionResolver(@Nullable XPathFunctionResolver xPathFunctionResolver) {
         this.xPathFunctionResolver = xPathFunctionResolver;
         return this;
     }

--- a/ph-schematron/src/main/java/com/helger/schematron/config/XPathConfigBuilder.java
+++ b/ph-schematron/src/main/java/com/helger/schematron/config/XPathConfigBuilder.java
@@ -50,9 +50,14 @@ public class XPathConfigBuilder {
 
     public XPathConfig build() throws XPathFactoryConfigurationException {
         try {
-            XPathFactory xPathFactory = xPathFactoryClass.getConstructor(EMPTY_CLASS_ARRAY)
+            /*
+            XPathFactory aXPathFactory = XPathFactory.newInstance (XPathFactory.DEFAULT_OBJECT_MODEL_URI,
+                    "net.sf.saxon.xpath.XPathFactoryImpl",
+                    ClassLoaderHelper.getContextClassLoader ());
+                    */
+            XPathFactory aXPathFactory = xPathFactoryClass.getConstructor(EMPTY_CLASS_ARRAY)
                     .newInstance(EMPTY_OBJECT_ARRAY);
-            XPathConfig result = new XPathConfig(xPathFactory, xPathVariableResolver, xPathFunctionResolver);
+            XPathConfig result = new XPathConfigImpl(aXPathFactory, xPathVariableResolver, xPathFunctionResolver);
             return result;
         } catch (InstantiationException e) {
             throw new XPathFactoryConfigurationException(e);

--- a/ph-schematron/src/main/java/com/helger/schematron/config/XPathConfigImpl.java
+++ b/ph-schematron/src/main/java/com/helger/schematron/config/XPathConfigImpl.java
@@ -1,0 +1,62 @@
+package com.helger.schematron.config;
+
+import javax.xml.xpath.XPathFactory;
+import javax.xml.xpath.XPathFunctionResolver;
+import javax.xml.xpath.XPathVariableResolver;
+import java.util.Objects;
+
+public class XPathConfigImpl implements XPathConfig {
+
+    private final XPathFactory xPathFactory;
+
+    private final XPathVariableResolver xPathVariableResolver;
+
+    private final XPathFunctionResolver xPathFunctionResolver;
+
+    XPathConfigImpl(XPathFactory xPathFactory, XPathVariableResolver xPathVariableResolver,
+                           XPathFunctionResolver xPathFunctionResolver) {
+        this.xPathFactory = xPathFactory;
+        this.xPathVariableResolver = xPathVariableResolver;
+        this.xPathFunctionResolver = xPathFunctionResolver;
+    }
+
+    @Override
+    public XPathFactory getXPathFactory() {
+        return xPathFactory;
+    }
+
+    @Override
+    public XPathVariableResolver getXPathVariableResolver() {
+        return xPathVariableResolver;
+    }
+
+    @Override
+    public XPathFunctionResolver getXPathFunctionResolver() {
+        return xPathFunctionResolver;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof XPathConfigImpl)) return false;
+        XPathConfigImpl that = (XPathConfigImpl) o;
+        return xPathFactory.equals(that.xPathFactory) &&
+                Objects.equals(xPathVariableResolver, that.xPathVariableResolver) &&
+                Objects.equals(xPathFunctionResolver, that.xPathFunctionResolver);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(xPathFactory, xPathVariableResolver, xPathFunctionResolver);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("XPathConfig{");
+        sb.append("xPathFactory=").append(xPathFactory);
+        sb.append(", xPathVariableResolver=").append(xPathVariableResolver);
+        sb.append(", xPathFunctionResolver=").append(xPathFunctionResolver);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/ph-schematron/src/main/java/com/helger/schematron/config/XPathConfigImpl.java
+++ b/ph-schematron/src/main/java/com/helger/schematron/config/XPathConfigImpl.java
@@ -1,10 +1,14 @@
 package com.helger.schematron.config;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
 import javax.xml.xpath.XPathFactory;
 import javax.xml.xpath.XPathFunctionResolver;
 import javax.xml.xpath.XPathVariableResolver;
 import java.util.Objects;
 
+@Immutable
 public class XPathConfigImpl implements XPathConfig {
 
     private final XPathFactory xPathFactory;
@@ -13,8 +17,8 @@ public class XPathConfigImpl implements XPathConfig {
 
     private final XPathFunctionResolver xPathFunctionResolver;
 
-    XPathConfigImpl(XPathFactory xPathFactory, XPathVariableResolver xPathVariableResolver,
-                           XPathFunctionResolver xPathFunctionResolver) {
+    XPathConfigImpl(@Nonnull XPathFactory xPathFactory, @Nullable XPathVariableResolver xPathVariableResolver,
+                    @Nullable XPathFunctionResolver xPathFunctionResolver) {
         this.xPathFactory = xPathFactory;
         this.xPathVariableResolver = xPathVariableResolver;
         this.xPathFunctionResolver = xPathFunctionResolver;

--- a/ph-schematron/src/main/java/com/helger/schematron/config/XPathConfigs.java
+++ b/ph-schematron/src/main/java/com/helger/schematron/config/XPathConfigs.java
@@ -9,7 +9,7 @@ import javax.xml.xpath.XPathVariableResolver;
 
 public class XPathConfigs {
 
-    private static final XPathFactory SAXON_FIRST = XPathHelper.createXPathFactorySaxonFirst ();
+    static final XPathFactory SAXON_FIRST = XPathHelper.createXPathFactorySaxonFirst ();
 
     public static final XPathConfig DEFAULT = new XPathConfigImpl(SAXON_FIRST, null, null);
 }

--- a/ph-schematron/src/main/java/com/helger/schematron/config/XPathConfigs.java
+++ b/ph-schematron/src/main/java/com/helger/schematron/config/XPathConfigs.java
@@ -1,11 +1,8 @@
 package com.helger.schematron.config;
 
-import com.helger.schematron.pure.bound.xpath.PSXPathBoundSchema;
 import com.helger.xml.xpath.XPathHelper;
 
 import javax.xml.xpath.XPathFactory;
-import javax.xml.xpath.XPathFunctionResolver;
-import javax.xml.xpath.XPathVariableResolver;
 
 public class XPathConfigs {
 

--- a/ph-schematron/src/main/java/com/helger/schematron/config/XPathConfigs.java
+++ b/ph-schematron/src/main/java/com/helger/schematron/config/XPathConfigs.java
@@ -1,0 +1,15 @@
+package com.helger.schematron.config;
+
+import com.helger.schematron.pure.bound.xpath.PSXPathBoundSchema;
+import com.helger.xml.xpath.XPathHelper;
+
+import javax.xml.xpath.XPathFactory;
+import javax.xml.xpath.XPathFunctionResolver;
+import javax.xml.xpath.XPathVariableResolver;
+
+public class XPathConfigs {
+
+    private static final XPathFactory SAXON_FIRST = XPathHelper.createXPathFactorySaxonFirst ();
+
+    public static final XPathConfig DEFAULT = new XPathConfigImpl(SAXON_FIRST, null, null);
+}

--- a/ph-schematron/src/main/java/com/helger/schematron/pure/SchematronResourcePure.java
+++ b/ph-schematron/src/main/java/com/helger/schematron/pure/SchematronResourcePure.java
@@ -28,6 +28,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 import javax.xml.xpath.XPathFunctionResolver;
 import javax.xml.xpath.XPathVariableResolver;
 
+import com.helger.schematron.config.XPathConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -81,8 +82,7 @@ public class SchematronResourcePure extends AbstractSchematronResource
   private String m_sPhase;
   private IPSErrorHandler m_aErrorHandler;
   private IPSValidationHandler m_aCustomValidationHandler;
-  private XPathVariableResolver m_aVariableResolver;
-  private XPathFunctionResolver m_aFunctionResolver;
+  private XPathConfig m_aXPathConfig;
   // Status var
   private IPSBoundSchema m_aBoundSchema;
 
@@ -201,24 +201,24 @@ public class SchematronResourcePure extends AbstractSchematronResource
   @Nullable
   public final XPathVariableResolver getVariableResolver ()
   {
-    return m_aVariableResolver;
+    return m_aXPathConfig.getXPathVariableResolver();
   }
 
   /**
-   * Set the variable resolver to be used in the XPath statements. This can only
+   * Set the {@link XPathConfig} to be used in the XPath statements. This can only
    * be set before the Schematron is bound. If it is already bound an exception
    * is thrown to indicate the unnecessity of the call.
    *
-   * @param aVariableResolver
-   *        The variable resolver to set. May be <code>null</code>.
+   * @param aXPathConfig
+   *        The xpath config to set. May be <code>null</code>.
    * @return this
    */
   @Nonnull
-  public final SchematronResourcePure setVariableResolver (@Nullable final XPathVariableResolver aVariableResolver)
+  public final SchematronResourcePure setXPathConfig (@Nonnull final XPathConfig aXPathConfig)
   {
     if (m_aBoundSchema != null)
       throw new IllegalStateException ("Schematron was already bound and can therefore not be altered!");
-    m_aVariableResolver = aVariableResolver;
+    m_aXPathConfig = aXPathConfig;
     return this;
   }
 
@@ -228,25 +228,7 @@ public class SchematronResourcePure extends AbstractSchematronResource
   @Nullable
   public final XPathFunctionResolver getFunctionResolver ()
   {
-    return m_aFunctionResolver;
-  }
-
-  /**
-   * Set the function resolver to be used in the XPath statements. This can only
-   * be set before the Schematron is bound. If it is already bound an exception
-   * is thrown to indicate the unnecessity of the call.
-   *
-   * @param aFunctionResolver
-   *        The function resolver to set. May be <code>null</code>.
-   * @return this
-   */
-  @Nonnull
-  public final SchematronResourcePure setFunctionResolver (@Nullable final XPathFunctionResolver aFunctionResolver)
-  {
-    if (m_aBoundSchema != null)
-      throw new IllegalStateException ("Schematron was already bound and can therefore not be altered!");
-    m_aFunctionResolver = aFunctionResolver;
-    return this;
+    return m_aXPathConfig.getXPathFunctionResolver();
   }
 
   /**
@@ -277,8 +259,7 @@ public class SchematronResourcePure extends AbstractSchematronResource
                                                                        m_sPhase,
                                                                        m_aErrorHandler,
                                                                        m_aCustomValidationHandler,
-                                                                       m_aVariableResolver,
-                                                                       m_aFunctionResolver,
+                                                                       m_aXPathConfig,
                                                                        getEntityResolver (),
                                                                        isLenient ());
     if (aResource instanceof AbstractMemoryReadableResource || !isUseCache ())

--- a/ph-schematron/src/main/java/com/helger/schematron/pure/SchematronResourcePure.java
+++ b/ph-schematron/src/main/java/com/helger/schematron/pure/SchematronResourcePure.java
@@ -29,6 +29,8 @@ import javax.xml.xpath.XPathFunctionResolver;
 import javax.xml.xpath.XPathVariableResolver;
 
 import com.helger.schematron.config.XPathConfig;
+import com.helger.schematron.config.XPathConfigImpl;
+import com.helger.schematron.config.XPathConfigs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -82,7 +84,7 @@ public class SchematronResourcePure extends AbstractSchematronResource
   private String m_sPhase;
   private IPSErrorHandler m_aErrorHandler;
   private IPSValidationHandler m_aCustomValidationHandler;
-  private XPathConfig m_aXPathConfig;
+  private XPathConfig m_aXPathConfig = XPathConfigs.DEFAULT;
   // Status var
   private IPSBoundSchema m_aBoundSchema;
 
@@ -205,7 +207,7 @@ public class SchematronResourcePure extends AbstractSchematronResource
   }
 
   /**
-   * Set the {@link XPathConfig} to be used in the XPath statements. This can only
+   * Set the {@link XPathConfigImpl} to be used in the XPath statements. This can only
    * be set before the Schematron is bound. If it is already bound an exception
    * is thrown to indicate the unnecessity of the call.
    *

--- a/ph-schematron/src/main/java/com/helger/schematron/pure/binding/IPSQueryBinding.java
+++ b/ph-schematron/src/main/java/com/helger/schematron/pure/binding/IPSQueryBinding.java
@@ -22,13 +22,12 @@ import java.util.Map;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import javax.xml.xpath.XPathFunctionResolver;
-import javax.xml.xpath.XPathVariableResolver;
 
 import com.helger.commons.annotation.ReturnsMutableCopy;
 import com.helger.commons.collection.impl.ICommonsNavigableMap;
 import com.helger.schematron.SchematronException;
 import com.helger.schematron.config.XPathConfig;
+import com.helger.schematron.config.XPathConfigImpl;
 import com.helger.schematron.pure.bound.IPSBoundSchema;
 import com.helger.schematron.pure.errorhandler.IPSErrorHandler;
 import com.helger.schematron.pure.model.PSAssertReport;
@@ -132,7 +131,7 @@ public interface IPSQueryBinding extends Serializable
    * @param aCustomValidationHandler
    *        A custom PS validation handler to use. May be <code>null</code>.
    * @param aXPathConfig
-   *        Use {@link XPathConfig}.
+   *        Use {@link XPathConfigImpl}.
    * @return The precompiled, bound schema. Never <code>null</code>.
    * @throws SchematronException
    *         In case of a binding error

--- a/ph-schematron/src/main/java/com/helger/schematron/pure/binding/IPSQueryBinding.java
+++ b/ph-schematron/src/main/java/com/helger/schematron/pure/binding/IPSQueryBinding.java
@@ -28,6 +28,7 @@ import javax.xml.xpath.XPathVariableResolver;
 import com.helger.commons.annotation.ReturnsMutableCopy;
 import com.helger.commons.collection.impl.ICommonsNavigableMap;
 import com.helger.schematron.SchematronException;
+import com.helger.schematron.config.XPathConfig;
 import com.helger.schematron.pure.bound.IPSBoundSchema;
 import com.helger.schematron.pure.errorhandler.IPSErrorHandler;
 import com.helger.schematron.pure.model.PSAssertReport;
@@ -97,22 +98,23 @@ public interface IPSQueryBinding extends Serializable
   // --- requirements for compilation ---
 
   @Nonnull
-  default IPSBoundSchema bind (@Nonnull final PSSchema aSchema) throws SchematronException
+  default IPSBoundSchema bind (@Nonnull final PSSchema aSchema,
+                               @Nonnull final XPathConfig aXPathConfig) throws SchematronException
   {
-    return bind (aSchema, (String) null, (IPSErrorHandler) null);
+    return bind (aSchema, (String) null, (IPSErrorHandler) null, aXPathConfig);
   }
 
   @Nonnull
   default IPSBoundSchema bind (@Nonnull final PSSchema aSchema,
                                @Nullable final String sPhase,
-                               @Nullable final IPSErrorHandler aCustomErrorListener) throws SchematronException
+                               @Nullable final IPSErrorHandler aCustomErrorListener,
+                               @Nonnull final XPathConfig aXPathConfig) throws SchematronException
   {
     return bind (aSchema,
                  sPhase,
                  aCustomErrorListener,
                  (IPSValidationHandler) null,
-                 (XPathVariableResolver) null,
-                 (XPathFunctionResolver) null);
+                 (XPathConfig) aXPathConfig);
   }
 
   /**
@@ -129,10 +131,8 @@ public interface IPSQueryBinding extends Serializable
    *        An optional custom error handler to use. May be <code>null</code>.
    * @param aCustomValidationHandler
    *        A custom PS validation handler to use. May be <code>null</code>.
-   * @param aVariableResolver
-   *        Custom variable resolver. May be <code>null</code>.
-   * @param aFunctionResolver
-   *        Custom function resolver. May be <code>null</code>.
+   * @param aXPathConfig
+   *        Use {@link XPathConfig}.
    * @return The precompiled, bound schema. Never <code>null</code>.
    * @throws SchematronException
    *         In case of a binding error
@@ -142,6 +142,5 @@ public interface IPSQueryBinding extends Serializable
                        @Nullable String sPhase,
                        @Nullable IPSErrorHandler aCustomErrorHandler,
                        @Nullable IPSValidationHandler aCustomValidationHandler,
-                       @Nullable XPathVariableResolver aVariableResolver,
-                       @Nullable XPathFunctionResolver aFunctionResolver) throws SchematronException;
+                       @Nonnull XPathConfig aXPathConfig) throws SchematronException;
 }

--- a/ph-schematron/src/main/java/com/helger/schematron/pure/binding/xpath/PSXPathQueryBinding.java
+++ b/ph-schematron/src/main/java/com/helger/schematron/pure/binding/xpath/PSXPathQueryBinding.java
@@ -24,6 +24,7 @@ import javax.annotation.Nullable;
 import javax.xml.xpath.XPathFunctionResolver;
 import javax.xml.xpath.XPathVariableResolver;
 
+import com.helger.schematron.config.XPathConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -116,8 +117,7 @@ public class PSXPathQueryBinding implements IPSQueryBinding
                               @Nullable final String sPhase,
                               @Nullable final IPSErrorHandler aCustomErrorListener,
                               @Nullable final IPSValidationHandler aCustomValidationHandler,
-                              @Nullable final XPathVariableResolver aVariableResolver,
-                              @Nullable final XPathFunctionResolver aFunctionResolver) throws SchematronException
+                              @Nonnull final XPathConfig aXPathConfig) throws SchematronException
   {
     ValueEnforcer.notNull (aSchema, "Schema");
 
@@ -145,8 +145,7 @@ public class PSXPathQueryBinding implements IPSQueryBinding
                                                            sPhase,
                                                            aCustomErrorListener,
                                                            aCustomValidationHandler,
-                                                           aVariableResolver,
-                                                           aFunctionResolver);
+                                                           aXPathConfig);
     ret.bind ();
     return ret;
   }

--- a/ph-schematron/src/main/java/com/helger/schematron/pure/bound/PSBoundSchemaCacheKey.java
+++ b/ph-schematron/src/main/java/com/helger/schematron/pure/bound/PSBoundSchemaCacheKey.java
@@ -22,6 +22,7 @@ import javax.annotation.concurrent.Immutable;
 import javax.xml.xpath.XPathFunctionResolver;
 import javax.xml.xpath.XPathVariableResolver;
 
+import com.helger.schematron.config.XPathConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.EntityResolver;
@@ -61,8 +62,7 @@ public class PSBoundSchemaCacheKey
   private final String m_sPhase;
   private final IPSErrorHandler m_aErrorHandler;
   private final IPSValidationHandler m_aCustomValidationHandler;
-  private final XPathVariableResolver m_aVariableResolver;
-  private final XPathFunctionResolver m_aFunctionResolver;
+  private final XPathConfig m_aXPathConfig;
   private final EntityResolver m_aEntityResolver;
   private final boolean m_bLenient;
   // Status vars
@@ -72,8 +72,7 @@ public class PSBoundSchemaCacheKey
                                 @Nullable final String sPhase,
                                 @Nullable final IPSErrorHandler aErrorHandler,
                                 @Nullable final IPSValidationHandler aCustomValidationHandler,
-                                @Nullable final XPathVariableResolver aVariableResolver,
-                                @Nullable final XPathFunctionResolver aFunctionResolver,
+                                @Nonnull final XPathConfig aXPathConfig,
                                 @Nullable final EntityResolver aEntityResolver,
                                 final boolean bLenient)
   {
@@ -83,8 +82,7 @@ public class PSBoundSchemaCacheKey
     m_sPhase = sPhase;
     m_aErrorHandler = aErrorHandler;
     m_aCustomValidationHandler = aCustomValidationHandler;
-    m_aVariableResolver = aVariableResolver;
-    m_aFunctionResolver = aFunctionResolver;
+    m_aXPathConfig = aXPathConfig;
     m_aEntityResolver = aEntityResolver;
     m_bLenient = bLenient;
   }
@@ -138,7 +136,7 @@ public class PSBoundSchemaCacheKey
   @Nullable
   public final XPathVariableResolver getVariableResolver ()
   {
-    return m_aVariableResolver;
+    return m_aXPathConfig.getXPathVariableResolver();
   }
 
   /**
@@ -147,7 +145,7 @@ public class PSBoundSchemaCacheKey
   @Nullable
   public final XPathFunctionResolver getFunctionResolver ()
   {
-    return m_aFunctionResolver;
+    return m_aXPathConfig.getXPathFunctionResolver();
   }
 
   /**
@@ -278,8 +276,7 @@ public class PSBoundSchemaCacheKey
                                m_sPhase,
                                m_aErrorHandler,
                                m_aCustomValidationHandler,
-                               m_aVariableResolver,
-                               m_aFunctionResolver);
+                               m_aXPathConfig);
   }
 
   @Override
@@ -292,8 +289,7 @@ public class PSBoundSchemaCacheKey
     final PSBoundSchemaCacheKey rhs = (PSBoundSchemaCacheKey) o;
     return m_aResource.equals (rhs.m_aResource) &&
            EqualsHelper.equals (m_sPhase, rhs.m_sPhase) &&
-           EqualsHelper.equals (m_aVariableResolver, rhs.m_aVariableResolver) &&
-           EqualsHelper.equals (m_aFunctionResolver, rhs.m_aFunctionResolver);
+           EqualsHelper.equals (m_aXPathConfig, rhs.m_aXPathConfig);
   }
 
   @Override
@@ -303,8 +299,7 @@ public class PSBoundSchemaCacheKey
     if (ret == IHashCodeGenerator.ILLEGAL_HASHCODE)
       ret = m_nHashCode = new HashCodeGenerator (this).append (m_aResource)
                                                       .append (m_sPhase)
-                                                      .append (m_aVariableResolver)
-                                                      .append (m_aFunctionResolver)
+                                                      .append (m_aXPathConfig)
                                                       .getHashCode ();
     return ret;
   }
@@ -315,8 +310,7 @@ public class PSBoundSchemaCacheKey
     return new ToStringGenerator (this).append ("resource", m_aResource)
                                        .append ("phase", m_sPhase)
                                        .appendIfNotNull ("errorHandler", m_aErrorHandler)
-                                       .appendIfNotNull ("variableResolver", m_aVariableResolver)
-                                       .appendIfNotNull ("functionResolver", m_aFunctionResolver)
+                                       .appendIfNotNull ("XPathConfig", m_aXPathConfig)
                                        .getToString ();
   }
 }

--- a/ph-schematron/src/main/java/com/helger/schematron/pure/bound/PSBoundSchemaCacheKey.java
+++ b/ph-schematron/src/main/java/com/helger/schematron/pure/bound/PSBoundSchemaCacheKey.java
@@ -23,6 +23,7 @@ import javax.xml.xpath.XPathFunctionResolver;
 import javax.xml.xpath.XPathVariableResolver;
 
 import com.helger.schematron.config.XPathConfig;
+import com.helger.schematron.config.XPathConfigs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.EntityResolver;

--- a/ph-schematron/src/main/java/com/helger/schematron/pure/bound/xpath/PSXPathBoundSchema.java
+++ b/ph-schematron/src/main/java/com/helger/schematron/pure/bound/xpath/PSXPathBoundSchema.java
@@ -29,6 +29,8 @@ import javax.xml.xpath.XPathFunctionResolver;
 import javax.xml.xpath.XPathVariableResolver;
 
 import com.helger.schematron.config.XPathConfig;
+import com.helger.schematron.config.XPathConfigImpl;
+import com.helger.schematron.config.XPathConfigs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Node;
@@ -386,7 +388,7 @@ public class PSXPathBoundSchema extends AbstractPSBoundSchema
    * @param aCustomValidationHandler
    *        The custom PS validation handler. May be <code>null</code>.
    * @param aXPathConfig
-   *        Used {@link XPathConfig}.
+   *        Used {@link XPathConfigImpl}.
    * @throws SchematronBindException
    *         In case XPath expressions are incorrect and pre-compilation fails
    */

--- a/ph-schematron/src/main/java/com/helger/schematron/pure/bound/xpath/PSXPathBoundSchema.java
+++ b/ph-schematron/src/main/java/com/helger/schematron/pure/bound/xpath/PSXPathBoundSchema.java
@@ -403,7 +403,8 @@ public class PSXPathBoundSchema extends AbstractPSBoundSchema
     super (aQueryBinding, aOrigSchema, sPhase, aCustomErrorListener, aCustomValidationHandler);
     m_aXPathVariableResolver = aXPathVariableResolver;
     m_aXPathFunctionResolver = aXPathFunctionResolver;
-    m_aXPathFactory = createXPathFactorySaxonFirst ();
+    // m_aXPathFactory = createXPathFactorySaxonFirst ();
+    m_aXPathFactory = XPathHelper.getDefaultXPathFactory();
   }
 
   @Nonnull

--- a/ph-schematron/src/test/java/com/helger/schematron/docs/DocumentationExamples.java
+++ b/ph-schematron/src/test/java/com/helger/schematron/docs/DocumentationExamples.java
@@ -21,6 +21,8 @@ import java.io.File;
 import javax.annotation.Nonnull;
 import javax.xml.transform.stream.StreamSource;
 
+import com.helger.schematron.config.XPathConfig;
+import com.helger.schematron.config.XPathConfigBuilder;
 import org.w3c.dom.Document;
 
 import com.helger.commons.io.file.FileHelper;
@@ -87,8 +89,11 @@ public final class DocumentationExamples
     final PSPreprocessor aPreprocessor = new PSPreprocessor (aQueryBinding);
     aPreprocessor.setKeepTitles (true);
     final PSSchema aPreprocessedSchema = aPreprocessor.getAsPreprocessedSchema (aSchema);
+
+    XPathConfig aXPathConfig = new XPathConfigBuilder().build();
     // Bind the pre-processed schema
-    final IPSBoundSchema aBoundSchema = aQueryBinding.bind (aPreprocessedSchema, null, null);
+    final IPSBoundSchema aBoundSchema = aQueryBinding.bind (aPreprocessedSchema, null, null,
+            aXPathConfig);
     // Read the XML file
     final Document aXMLNode = DOMReader.readXMLDOM (aXMLFile);
     if (aXMLNode == null)

--- a/ph-schematron/src/test/java/com/helger/schematron/pure/SchematronResourcePureTest.java
+++ b/ph-schematron/src/test/java/com/helger/schematron/pure/SchematronResourcePureTest.java
@@ -25,7 +25,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import javax.xml.validation.Schema;
+import javax.xml.xpath.XPathFactoryConfigurationException;
 
+import com.helger.schematron.config.XPathConfig;
+import com.helger.schematron.config.XPathConfigBuilder;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
@@ -136,8 +139,7 @@ public final class SchematronResourcePureTest
   }
 
   @Test
-  public void testResolveVariables () throws SchematronException
-  {
+  public void testResolveVariables () throws SchematronException, XPathFactoryConfigurationException {
     final String sTest = "<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>\n" +
                          "<iso:schema xmlns=\"http://purl.oclc.org/dsdl/schematron\" \n" +
                          "         xmlns:iso=\"http://purl.oclc.org/dsdl/schematron\" \n" +
@@ -179,10 +181,13 @@ public final class SchematronResourcePureTest
       final List <?> aArg = (List <?>) args.get (0);
       return Integer.valueOf (aArg.size ());
     });
+    XPathConfig aXPathConfig = new XPathConfigBuilder()
+            .setXPathVariableResolver(aVarResolver)
+            .setXPathFunctionResolver(aFunctionResolver).build();
+
     final Document aTestDoc = DOMReader.readXMLDOM ("<?xml version='1.0'?><chapter><title /><para>First para</para><para>Second para</para></chapter>");
     final SchematronOutputType aOT = SchematronResourcePure.fromString (sTest, StandardCharsets.UTF_8)
-                                                           .setVariableResolver (aVarResolver)
-                                                           .setFunctionResolver (aFunctionResolver)
+                                                           .setXPathConfig (aXPathConfig)
                                                            .applySchematronValidationToSVRL (aTestDoc, null);
     assertNotNull (aOT);
     assertEquals (0, SVRLHelper.getAllFailedAssertions (aOT).size ());
@@ -192,8 +197,7 @@ public final class SchematronResourcePureTest
   }
 
   @Test
-  public void testResolveFunctions () throws SchematronException
-  {
+  public void testResolveFunctions () throws SchematronException, XPathFactoryConfigurationException {
     final String sTest = "<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>\n" +
                          "<iso:schema xmlns=\"http://purl.oclc.org/dsdl/schematron\" \n" +
                          "         xmlns:iso=\"http://purl.oclc.org/dsdl/schematron\" \n" +
@@ -250,9 +254,12 @@ public final class SchematronResourcePureTest
                                                     "<para>First para</para>" +
                                                     "<para>Second para</para>" +
                                                     "</chapter>");
-    final SchematronOutputType aOT = SchematronResourcePure.fromString (sTest, StandardCharsets.UTF_8)
-                                                           .setFunctionResolver (aFunctionResolver)
-                                                           .applySchematronValidationToSVRL (aTestDoc, null);
+    XPathConfig aXPathConfig = new XPathConfigBuilder()
+            .setXPathFunctionResolver(aFunctionResolver)
+            .build();
+    final SchematronOutputType aOT = SchematronResourcePure.fromByteArray (sTest.getBytes (StandardCharsets.UTF_8))
+            .setXPathConfig(aXPathConfig)
+            .applySchematronValidationToSVRL(aTestDoc, null);
     assertNotNull (aOT);
     assertEquals (0, SVRLHelper.getAllFailedAssertions (aOT).size ());
     assertEquals (1, SVRLHelper.getAllSuccessfulReports (aOT).size ());
@@ -295,9 +302,12 @@ public final class SchematronResourcePureTest
                                                     "<para>First para</para>" +
                                                     "<para>Second para</para>" +
                                                     "</chapter>");
-    final SchematronOutputType aOT = SchematronResourcePure.fromString (sTest, StandardCharsets.UTF_8)
-                                                           .setFunctionResolver (aFunctionResolver)
-                                                           .applySchematronValidationToSVRL (aTestDoc, null);
+    XPathConfig aXPathConfig = new XPathConfigBuilder()
+            .setXPathFunctionResolver(aFunctionResolver)
+            .build();
+    final SchematronOutputType aOT = SchematronResourcePure.fromByteArray (sTest.getBytes (StandardCharsets.UTF_8))
+            .setXPathConfig(aXPathConfig)
+            .applySchematronValidationToSVRL(aTestDoc, null);
     assertNotNull (aOT);
     assertEquals (0, SVRLHelper.getAllFailedAssertions (aOT).size ());
     assertEquals (1, SVRLHelper.getAllSuccessfulReports (aOT).size ());
@@ -337,10 +347,13 @@ public final class SchematronResourcePureTest
                                                     "<para>200</para>" +
                                                     "</chapter>");
     final CollectingPSErrorHandler aErrorHandler = new CollectingPSErrorHandler (new LoggingPSErrorHandler ());
-    final SchematronOutputType aOT = SchematronResourcePure.fromString (sTest, StandardCharsets.UTF_8)
-                                                           .setFunctionResolver (aFunctionResolver)
-                                                           .setErrorHandler (aErrorHandler)
-                                                           .applySchematronValidationToSVRL (aTestDoc, null);
+    XPathConfig aXPathConfig = new XPathConfigBuilder()
+            .setXPathFunctionResolver(aFunctionResolver)
+            .build();
+    final SchematronOutputType aOT = SchematronResourcePure.fromByteArray (sTest.getBytes (StandardCharsets.UTF_8))
+            .setXPathConfig(aXPathConfig)
+            .setErrorHandler(aErrorHandler)
+            .applySchematronValidationToSVRL(aTestDoc, null);
     assertNotNull (aOT);
     // XXX fails :(
     if (false)
@@ -376,9 +389,12 @@ public final class SchematronResourcePureTest
                                                     "</chapter>",
                                                     new DOMReaderSettings ().setSchema (aSchema));
 
-    final SchematronOutputType aOT = SchematronResourcePure.fromString (sTest, StandardCharsets.UTF_8)
-                                                           .setFunctionResolver (aFunctionResolver)
-                                                           .applySchematronValidationToSVRL (aTestDoc, null);
+    XPathConfig aXPathConfig = new XPathConfigBuilder()
+            .setXPathFunctionResolver(aFunctionResolver)
+            .build();
+    final SchematronOutputType aOT = SchematronResourcePure.fromByteArray (sTest.getBytes (StandardCharsets.UTF_8))
+            .setXPathConfig(aXPathConfig)
+            .applySchematronValidationToSVRL(aTestDoc, null);
     assertNotNull (aOT);
     if (SVRLHelper.getAllFailedAssertions (aOT).size () != 0)
     {

--- a/ph-schematron/src/test/java/com/helger/schematron/pure/bound/xpath/PSXPathBoundSchemaTest.java
+++ b/ph-schematron/src/test/java/com/helger/schematron/pure/bound/xpath/PSXPathBoundSchemaTest.java
@@ -19,6 +19,8 @@ package com.helger.schematron.pure.bound.xpath;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.helger.schematron.config.XPathConfig;
+import com.helger.schematron.config.XPathConfigBuilder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
@@ -45,6 +47,8 @@ import com.helger.schematron.testfiles.SchematronTestHelper;
 import com.helger.xml.microdom.IMicroDocument;
 import com.helger.xml.serialize.read.DOMReader;
 
+import javax.xml.xpath.XPathFactoryConfigurationException;
+
 /**
  * Test class for class {@link PSPreprocessor}.
  *
@@ -70,8 +74,7 @@ public final class PSXPathBoundSchemaTest
                                                        "valid01.xml" };
 
   @Test
-  public void testSchematronValidation () throws SchematronException
-  {
+  public void testSchematronValidation () throws SchematronException, XPathFactoryConfigurationException {
     for (int i = 0; i < SCH.length; ++i)
     {
       final IReadableResource aSchRes = new ClassPathResource ("test-sch/" + SCH[i]);
@@ -86,10 +89,11 @@ public final class PSXPathBoundSchemaTest
       final PSSchema aSchema = aReader.readSchemaFromXML (aDoc.getDocumentElement ());
       assertNotNull (aSchema);
 
+      XPathConfig aXPathConfig = new XPathConfigBuilder().build();
       // Create a compiled schema
       final String sPhaseID = null;
       final IPSErrorHandler aErrorHandler = null;
-      final IPSBoundSchema aBoundSchema = PSXPathQueryBinding.getInstance ().bind (aSchema, sPhaseID, aErrorHandler);
+      final IPSBoundSchema aBoundSchema = PSXPathQueryBinding.getInstance ().bind (aSchema, sPhaseID, aErrorHandler, aXPathConfig);
 
       // Validate completely
       final SchematronOutputType aSVRL = aBoundSchema.validateComplete (DOMReader.readXMLDOM (aXmlRes),
@@ -102,8 +106,7 @@ public final class PSXPathBoundSchemaTest
   }
 
   @Test
-  public void testBindAllValidSchematrons () throws SchematronException
-  {
+  public void testBindAllValidSchematrons () throws SchematronException, XPathFactoryConfigurationException {
     for (final IReadableResource aRes : SchematronTestHelper.getAllValidSchematronFiles ())
     {
       // Parse the schema
@@ -115,17 +118,17 @@ public final class PSXPathBoundSchemaTest
       assertTrue (aRes.getPath (), aSchema.isValid (aLogger));
       assertTrue (aLogger.isEmpty ());
 
+      XPathConfig aXPathConfig = new XPathConfigBuilder().build();
       // Create a compiled schema
       final String sPhaseID = null;
       final IPSErrorHandler aErrorHandler = null;
-      final IPSBoundSchema aBoundSchema = PSXPathQueryBinding.getInstance ().bind (aSchema, sPhaseID, aErrorHandler);
+      final IPSBoundSchema aBoundSchema = PSXPathQueryBinding.getInstance ().bind (aSchema, sPhaseID, aErrorHandler, aXPathConfig);
       assertNotNull (aBoundSchema);
     }
   }
 
   @Test
-  public void testBindAllInvalidSchematrons ()
-  {
+  public void testBindAllInvalidSchematrons () throws XPathFactoryConfigurationException {
     for (final IReadableResource aRes : SchematronTestHelper.getAllInvalidSchematronFiles ())
     {
       LOGGER.info (aRes.toString ());
@@ -134,7 +137,8 @@ public final class PSXPathBoundSchemaTest
         // Parse the schema
         final PSSchema aSchema = new PSReader (aRes).readSchema ();
         final CollectingPSErrorHandler aCEH = new CollectingPSErrorHandler ();
-        PSXPathQueryBinding.getInstance ().bind (aSchema, null, aCEH);
+        XPathConfig aXPathConfig = new XPathConfigBuilder().build();
+        PSXPathQueryBinding.getInstance ().bind (aSchema, null, aCEH, aXPathConfig);
         // Either an ERROR was collected or an exception was thrown
         assertTrue (aCEH.getErrorList ().getMostSevereErrorLevel ().isGE (EErrorLevel.ERROR));
       }

--- a/ph-schematron/src/test/java/com/helger/schematron/supplementary/Issue16Test.java
+++ b/ph-schematron/src/test/java/com/helger/schematron/supplementary/Issue16Test.java
@@ -22,6 +22,8 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.xml.transform.stream.StreamSource;
 
+import com.helger.schematron.config.XPathConfig;
+import com.helger.schematron.config.XPathConfigBuilder;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.w3c.dom.Document;
@@ -92,8 +94,9 @@ public final class Issue16Test
       final PSPreprocessor aPreprocessor = new PSPreprocessor (aQueryBinding);
       aPreprocessor.setKeepTitles (true);
       final PSSchema aPreprocessedSchema = aPreprocessor.getAsPreprocessedSchema (aSchema);
+      XPathConfig aXPathConfig = new XPathConfigBuilder().build();
       // Bind the pre-processed schema
-      final IPSBoundSchema aBoundSchema = aQueryBinding.bind (aPreprocessedSchema);
+      final IPSBoundSchema aBoundSchema = aQueryBinding.bind (aPreprocessedSchema, aXPathConfig);
       // Read the XML file
       final Document aXMLNode = DOMReader.readXMLDOM (aXMLFile);
       if (aXMLNode == null)

--- a/ph-schematron/src/test/java/com/helger/schematron/supplementary/Issue20150128Test.java
+++ b/ph-schematron/src/test/java/com/helger/schematron/supplementary/Issue20150128Test.java
@@ -21,6 +21,8 @@ import static org.junit.Assert.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 
+import com.helger.schematron.config.XPathConfig;
+import com.helger.schematron.config.XPathConfigBuilder;
 import org.junit.Test;
 
 import com.helger.commons.io.resource.ClassPathResource;
@@ -53,7 +55,10 @@ public final class Issue20150128Test
     final SchematronResourcePure resource = SchematronResourcePure.fromString (sTest2, StandardCharsets.ISO_8859_1);
 
     resource.setErrorHandler (aErrorHandler);
-    resource.setFunctionResolver (aFunctionResolver);
+    XPathConfig aXPathConfig = new XPathConfigBuilder()
+            .setXPathFunctionResolver(aFunctionResolver)
+            .build();
+    resource.setXPathConfig (aXPathConfig);
     assertTrue (resource.isValidSchematron ());
     assertEquals (1, aErrorHandler.getErrorList ().size ());
   }

--- a/ph-schematron/src/test/java/com/helger/schematron/supplementary/Issue47Test.java
+++ b/ph-schematron/src/test/java/com/helger/schematron/supplementary/Issue47Test.java
@@ -22,6 +22,8 @@ import java.io.File;
 
 import javax.annotation.Nonnull;
 
+import com.helger.schematron.config.XPathConfig;
+import com.helger.schematron.config.XPathConfigBuilder;
 import org.junit.Test;
 
 import com.helger.commons.io.resource.FileSystemResource;
@@ -34,11 +36,14 @@ public final class Issue47Test
 
   public static void validateAndProduceSVRL (@Nonnull final File aSchematron, final File aXML) throws Exception
   {
-    final SchematronResourcePure aSCH = SchematronResourcePure.fromFile (aSchematron);
-    aSCH.setFunctionResolver ( (aFunctionName, aArity) -> {
-      System.out.println (aFunctionName + " - " + aArity);
-      return null;
-    });
+    XPathConfig aXPathConfig = new XPathConfigBuilder()
+            .setXPathFunctionResolver( (aFunctionName, aArity) -> {
+              System.out.println (aFunctionName + " - " + aArity);
+              return null;
+            })
+            .build();
+    final SchematronResourcePure aSCH = new SchematronResourcePure (new FileSystemResource (aSchematron))
+            .setXPathConfig(aXPathConfig);
 
     // Perform validation
     final SchematronOutputType aSVRL = aSCH.applySchematronValidationToSVRL (new FileSystemResource (aXML));


### PR DESCRIPTION
#96 
The only way to fix this is to make the XPath configuration in ph-schematron explicit. Hence I introduced the `XPathConfig` interface and a few supporting classes. The 'default' configuration has _not_ changed.