### PR TITLE
Feature/fix rich objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,10 @@ target/
 .project
 .classpath
 .factorypath
-zz
+
 ph-schematron/test-final/
 ph-schematron/test-minified/
 ph-schematron-pure/test-final/
 ph-schematron-pure/test-minified/
+
+.idea

--- a/ph-schematron/src/main/resources/schemas/svrl.xsd
+++ b/ph-schematron/src/main/resources/schemas/svrl.xsd
@@ -171,5 +171,6 @@
     <xs:attribute name="test" use="required"/>
     <xs:attribute name="role" type="xs:NMTOKEN"/>
     <xs:attribute name="flag" type="xs:NMTOKEN"/>
+    <xs:attribute name="see" />
   </xs:attributeGroup>
 </xs:schema>


### PR DESCRIPTION
This PR adds 
```
    @XmlAttribute(name = "see")
    @XmlSchemaType(name = "anySimpleType")
    private String see; 
```
to `com.helger.schematron.svrl.jaxb.SuccessfulReport` and `com.helger.schematron.svrl.jaxb.FailedAssert`. Without the `see` variable, the call `SchematronResourceXSLT().applySchematronValidationToSVRL()` fails with
```
javax.xml.bind.UnmarshalException: null
	at javax.xml.bind.helpers.AbstractUnmarshallerImpl.createUnmarshalException(AbstractUnmarshallerImpl.java:340) ~[jaxb-api-2.4.0-b180830.0359.jar:2.3.0]
	at com.sun.xml.bind.v2.runtime.unmarshaller.UnmarshallerImpl.createUnmarshalException(UnmarshallerImpl.java:548) ~[jaxb-impl-2.3.2.jar:2.3.2]
	at com.sun.xml.bind.v2.runtime.unmarshaller.UnmarshallerImpl.unmarshal0(UnmarshallerImpl.java:350) ~[jaxb-impl-2.3.2.jar:2.3.2]
	at com.sun.xml.bind.v2.runtime.unmarshaller.UnmarshallerImpl.unmarshal(UnmarshallerImpl.java:318) ~[jaxb-impl-2.3.2.jar:2.3.2]
	at com.helger.jaxb.IJAXBReader.lambda$read$1(IJAXBReader.java:343) ~[ph-jaxb-9.5.3.jar:9.5.3]
	at com.helger.jaxb.GenericJAXBMarshaller.read(GenericJAXBMarshaller.java:504) ~[ph-jaxb-9.5.3.jar:9.5.3]
	at com.helger.jaxb.IJAXBReader.read(IJAXBReader.java:343) ~[ph-jaxb-9.5.3.jar:9.5.3]
	at com.helger.schematron.xslt.AbstractSchematronXSLTBasedResource.applySchematronValidationToSVRL(AbstractSchematronXSLTBasedResource.java:310) ~[ph-schematron-5.6.5.jar:5.6.5]
	at com.helger.schematron.AbstractSchematronResource.applySchematronValidationToSVRL(AbstractSchematronResource.java:282) ~[ph-schematron-5.6.5.jar:5.6.5]
...
Caused by: org.xml.sax.SAXParseException: cvc-complex-type.3.2.2: Attribute 'see' is not allowed to appear in element 'svrl:successful-report'.
	at com.sun.org.apache.xerces.internal.util.ErrorHandlerWrapper.createSAXParseException(ErrorHandlerWrapper.java:204) ~[?:?]
	at com.sun.org.apache.xerces.internal.util.ErrorHandlerWrapper.error(ErrorHandlerWrapper.java:135) ~[?:?]
	at com.sun.org.apache.xerces.internal.impl.XMLErrorReporter.reportError(XMLErrorReporter.java:396) ~[?:?]
	at com.sun.org.apache.xerces.internal.impl.XMLErrorReporter.reportError(XMLErrorReporter.java:327) ~[?:?]
	at com.sun.org.apache.xerces.internal.impl.XMLErrorReporter.reportError(XMLErrorReporter.java:284) ~[?:?]
	at com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator$XSIErrorReporter.reportError(XMLSchemaValidator.java:511) ~[?:?]
	at com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator.reportSchemaError(XMLSchemaValidator.java:3587) ~[?:?]
	at com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator.processAttributes(XMLSchemaValidator.java:2992) ~[?:?]
	at com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator.handleStartElement(XMLSchemaValidator.java:2286) ~[?:?]
	at com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator.startElement(XMLSchemaValidator.java:829) ~[?:?]
	at com.sun.org.apache.xerces.internal.jaxp.validation.ValidatorHandlerImpl.startElement(ValidatorHandlerImpl.java:570) ~[?:?]
	at com.sun.xml.bind.v2.runtime.unmarshaller.ValidatingUnmarshaller.startElement(ValidatingUnmarshaller.java:71) ~[jaxb-impl-2.3.2.jar:2.3.2]
	at com.sun.xml.bind.v2.runtime.unmarshaller.InterningXmlVisitor.startElement(InterningXmlVisitor.java:45) ~[jaxb-impl-2.3.2.jar:2.3.2]
	at com.sun.xml.bind.v2.runtime.unmarshaller.SAXConnector.startElement(SAXConnector.java:138) ~[jaxb-impl-2.3.2.jar:2.3.2]
	at com.sun.xml.bind.unmarshaller.DOMScanner.visit(DOMScanner.java:214) ~[jaxb-impl-2.3.2.jar:2.3.2]
	at com.sun.xml.bind.unmarshaller.DOMScanner.visit(DOMScanner.java:251) ~[jaxb-impl-2.3.2.jar:2.3.2]
	at com.sun.xml.bind.unmarshaller.DOMScanner.visit(DOMScanner.java:220) ~[jaxb-impl-2.3.2.jar:2.3.2]
	at com.sun.xml.bind.unmarshaller.DOMScanner.scan(DOMScanner.java:97) ~[jaxb-impl-2.3.2.jar:2.3.2]
	at com.sun.xml.bind.unmarshaller.DOMScanner.scan(DOMScanner.java:80) ~[jaxb-impl-2.3.2.jar:2.3.2]
	at com.sun.xml.bind.v2.runtime.unmarshaller.UnmarshallerImpl.unmarshal0(UnmarshallerImpl.java:341) ~[jaxb-impl-2.3.2.jar:2.3.2]
```

when you compile the documents with 
```
        void customize(step: EStep, transformer: Transformer) {
            super.customize(step, transformer)

            if (step == EStep.SCH2XSLT_3) {
                transformer.setParameter("allow-foreign", "true")
            }
        }
```

I would love to also submit a test for this, but since this classes are autogenerated I have no idea how to write a test for it ;)

See also #101 for rule set examples with foreign objects.