### PR TITLE
Improve variable handling in pure mode

### DIFF
--- a/ph-schematron-pure/src/main/java/com/helger/schematron/pure/binding/xpath/IPSXPathVariables.java
+++ b/ph-schematron-pure/src/main/java/com/helger/schematron/pure/binding/xpath/IPSXPathVariables.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.xml.xpath.XPathExpression;
 
 import com.helger.commons.annotation.ReturnsMutableCopy;
 import com.helger.commons.collection.impl.ICommonsNavigableMap;
@@ -33,22 +34,11 @@ import com.helger.commons.lang.ICloneable;
 public interface IPSXPathVariables extends ICloneable <PSXPathVariables>, Serializable
 {
   /**
-   * Perform the text replacement of all variables in the specified text.
-   *
-   * @param sText
-   *        The source text. May be <code>null</code>.
-   * @return The text with all values replaced. May be <code>null</code> if the
-   *         source text is <code>null</code>.
-   */
-  @Nullable
-  String getAppliedReplacement (@Nullable String sText);
-
-  /**
    * @return All contained variable key value pairs. Never <code>null</code>.
    */
   @Nonnull
   @ReturnsMutableCopy
-  ICommonsNavigableMap <String, String> getAll ();
+  ICommonsNavigableMap <String, XPathExpression> getAll ();
 
   /**
    * @param sName
@@ -64,5 +54,5 @@ public interface IPSXPathVariables extends ICloneable <PSXPathVariables>, Serial
    *         <code>null</code> if no such variable is present.
    */
   @Nullable
-  String get (@Nullable String sName);
+  XPathExpression get (@Nullable String sName);
 }

--- a/ph-schematron-pure/src/main/java/com/helger/schematron/pure/binding/xpath/PSXPathVariables.java
+++ b/ph-schematron-pure/src/main/java/com/helger/schematron/pure/binding/xpath/PSXPathVariables.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
+import javax.xml.xpath.XPathExpression;
 
 import com.helger.commons.ValueEnforcer;
 import com.helger.commons.annotation.Nonempty;
@@ -42,12 +43,12 @@ public class PSXPathVariables implements IPSXPathVariables
 {
   @Nonnull
   @ReturnsMutableCopy
-  private static ICommonsNavigableMap <String, String> _createMap ()
+  private static ICommonsNavigableMap <String, XPathExpression> _createMap ()
   {
     return new CommonsTreeMap <> (IComparator.getComparatorStringLongestFirst ());
   }
 
-  private final ICommonsNavigableMap <String, String> m_aMap;
+  private final ICommonsNavigableMap <String, XPathExpression> m_aMap;
 
   public PSXPathVariables ()
   {
@@ -69,7 +70,7 @@ public class PSXPathVariables implements IPSXPathVariables
    *         already present. Never <code>null</code>.
    */
   @Nonnull
-  public EChange add (@Nonnull final Map.Entry <String, String> aEntry)
+  public EChange add (@Nonnull final Map.Entry <String, XPathExpression> aEntry)
   {
     return add (aEntry.getKey (), aEntry.getValue ());
   }
@@ -87,30 +88,16 @@ public class PSXPathVariables implements IPSXPathVariables
    *         already present. Never <code>null</code>.
    */
   @Nonnull
-  public EChange add (@Nonnull @Nonempty final String sName, @Nonnull @Nonempty final String sValue)
+  public EChange add (@Nonnull @Nonempty final String sName, @Nonnull @Nonempty final XPathExpression sValue)
   {
     ValueEnforcer.notEmpty (sName, "Name");
-    ValueEnforcer.notEmpty (sValue, "Value");
+    ValueEnforcer.notNull (sValue, "Value");
 
-    // Prepend the "$" prefix to the variable name
-    final String sRealName = PSXPathQueryBinding.PARAM_VARIABLE_PREFIX + sName;
-    if (m_aMap.containsKey (sRealName))
+    if (m_aMap.containsKey (sName))
       return EChange.UNCHANGED;
 
-    // Apply all existing variables to this variable value!
-    // This ensures that all variables used in variables are resolved correctly
-    // as long as the order of declaration is correct.
-    // Additionally this means that the order of the variables in this class is
-    // irrelevant
-    final String sRealValue = getAppliedReplacement (sValue);
-    m_aMap.put (sRealName, sRealValue);
+    m_aMap.put (sName, sValue);
     return EChange.CHANGED;
-  }
-
-  @Nullable
-  public String getAppliedReplacement (@Nullable final String sText)
-  {
-    return PSXPathQueryBinding.getWithParamTextsReplacedStatic (sText, m_aMap);
   }
 
   /**
@@ -150,7 +137,7 @@ public class PSXPathVariables implements IPSXPathVariables
 
   @Nonnull
   @ReturnsMutableCopy
-  public ICommonsNavigableMap <String, String> getAll ()
+  public ICommonsNavigableMap <String, XPathExpression> getAll ()
   {
     return m_aMap.getClone ();
   }
@@ -163,7 +150,7 @@ public class PSXPathVariables implements IPSXPathVariables
   }
 
   @Nullable
-  public String get (@Nullable final String sName)
+  public XPathExpression get (@Nullable final String sName)
   {
     if (StringHelper.hasNoText (sName))
       return null;

--- a/ph-schematron-pure/src/main/java/com/helger/schematron/pure/bound/xpath/PSXPathBoundPattern.java
+++ b/ph-schematron-pure/src/main/java/com/helger/schematron/pure/bound/xpath/PSXPathBoundPattern.java
@@ -23,6 +23,7 @@ import com.helger.commons.ValueEnforcer;
 import com.helger.commons.annotation.ReturnsMutableCopy;
 import com.helger.commons.collection.impl.ICommonsList;
 import com.helger.commons.string.ToStringGenerator;
+import com.helger.schematron.pure.binding.xpath.PSXPathVariables;
 import com.helger.schematron.pure.model.PSPattern;
 
 /**
@@ -35,14 +36,18 @@ public class PSXPathBoundPattern
 {
   private final PSPattern m_aPattern;
   private final ICommonsList <PSXPathBoundRule> m_aBoundRules;
+  private final PSXPathVariables m_aVariables;
 
   public PSXPathBoundPattern (@Nonnull final PSPattern aPattern,
-                              @Nonnull final ICommonsList <PSXPathBoundRule> aBoundRules)
+                              @Nonnull final ICommonsList <PSXPathBoundRule> aBoundRules,
+                              @Nonnull final PSXPathVariables aVariables)
   {
     ValueEnforcer.notNull (aPattern, "Pattern");
     ValueEnforcer.notNull (aBoundRules, "BoundRules");
+    ValueEnforcer.notNull (aVariables, "Variables");
     m_aPattern = aPattern;
     m_aBoundRules = aBoundRules;
+    m_aVariables = aVariables;
   }
 
   @Nonnull
@@ -58,11 +63,18 @@ public class PSXPathBoundPattern
     return m_aBoundRules.getClone ();
   }
 
+  @Nonnull
+  public final PSXPathVariables getVariables ()
+  {
+    return m_aVariables;
+  }
+
   @Override
   public String toString ()
   {
     return new ToStringGenerator (this).append ("Pattern", m_aPattern)
                                        .append ("BoundRules", m_aBoundRules)
+                                       .append ("Variables", m_aVariables)
                                        .getToString ();
   }
 }

--- a/ph-schematron-pure/src/main/java/com/helger/schematron/pure/bound/xpath/PSXPathBoundRule.java
+++ b/ph-schematron-pure/src/main/java/com/helger/schematron/pure/bound/xpath/PSXPathBoundRule.java
@@ -25,6 +25,7 @@ import com.helger.commons.annotation.ReturnsMutableCopy;
 import com.helger.commons.annotation.ReturnsMutableObject;
 import com.helger.commons.collection.impl.ICommonsList;
 import com.helger.commons.string.ToStringGenerator;
+import com.helger.schematron.pure.binding.xpath.PSXPathVariables;
 import com.helger.schematron.pure.model.PSRule;
 
 /**
@@ -39,20 +40,24 @@ public class PSXPathBoundRule
   private final String m_sRuleContext;
   private final XPathExpression m_aBoundRuleContext;
   private final ICommonsList <PSXPathBoundAssertReport> m_aBoundAssertReports;
+  private final PSXPathVariables m_aVariables;
 
   public PSXPathBoundRule (@Nonnull final PSRule aRule,
                            @Nonnull final String sRuleContext,
                            @Nonnull final XPathExpression aBoundRuleContext,
-                           @Nonnull final ICommonsList <PSXPathBoundAssertReport> aBoundAssertReports)
+                           @Nonnull final ICommonsList <PSXPathBoundAssertReport> aBoundAssertReports,
+                           @Nonnull final PSXPathVariables aVariables)
   {
     ValueEnforcer.notNull (aRule, "Rule");
     ValueEnforcer.notEmpty (sRuleContext, "RuleContext");
     ValueEnforcer.notNull (aBoundRuleContext, "BoundRuleContext");
     ValueEnforcer.notNull (aBoundAssertReports, "BoundAssertReports");
+    ValueEnforcer.notNull (aVariables, "Variables");
     m_aRule = aRule;
     m_sRuleContext = sRuleContext;
     m_aBoundRuleContext = aBoundRuleContext;
     m_aBoundAssertReports = aBoundAssertReports;
+    m_aVariables = aVariables;
   }
 
   @Nonnull
@@ -87,6 +92,13 @@ public class PSXPathBoundRule
     return m_aBoundAssertReports.getClone ();
   }
 
+  @Nonnull
+  public final PSXPathVariables getVariables ()
+  {
+    return m_aVariables;
+  }
+
+
   @Override
   public String toString ()
   {
@@ -94,6 +106,7 @@ public class PSXPathBoundRule
                                        .append ("RuleExpression", m_sRuleContext)
                                        .append ("BoundRuleExpression", m_aBoundRuleContext)
                                        .append ("BoundAssertReports", m_aBoundAssertReports)
+                                       .append ("Variables", m_aVariables)
                                        .getToString ();
   }
 }

--- a/ph-schematron-pure/src/main/java/com/helger/schematron/pure/xpath/LetVariableResolver.java
+++ b/ph-schematron-pure/src/main/java/com/helger/schematron/pure/xpath/LetVariableResolver.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2024 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.schematron.pure.xpath;
+
+import javax.annotation.Nullable;
+import javax.xml.namespace.QName;
+import javax.xml.xpath.XPathVariableResolver;
+
+import com.helger.commons.collection.impl.CommonsHashMap;
+import com.helger.commons.collection.impl.ICommonsMap;
+
+public class LetVariableResolver implements XPathVariableResolver
+{
+  private final XPathVariableResolver m_aDelegatedResolver;
+  private final ICommonsMap<QName, Object> m_aVariables;
+
+  public LetVariableResolver (XPathVariableResolver resolver)
+  {
+    this.m_aDelegatedResolver = resolver;
+    this.m_aVariables = new CommonsHashMap<> ();
+  }
+
+  public void setValue (QName variableName, Object value)
+  {
+    m_aVariables.put (variableName, value);
+  }
+
+    /**
+   * Remove all variables with the specified names
+   *
+   * @param aVarName
+   *        The variable name to be removed. May be <code>null</code>.
+   */
+  public void remove (@Nullable final QName aVarName)
+  {
+    if (aVarName != null)
+      m_aVariables.remove (aVarName);
+  }
+
+  @Override
+  public Object resolveVariable (QName variableName)
+  {
+    Object result = m_aVariables.get (variableName);
+    if (result == null && m_aDelegatedResolver != null) {
+      return m_aDelegatedResolver.resolveVariable (variableName);
+    }
+
+    return result;
+  }
+}

--- a/ph-schematron-pure/src/main/java/com/helger/schematron/pure/xpath/XPathConfig.java
+++ b/ph-schematron-pure/src/main/java/com/helger/schematron/pure/xpath/XPathConfig.java
@@ -47,7 +47,8 @@ public class XPathConfig implements IXPathConfig
   {
     ValueEnforcer.notNull (aXPathFactory, "XPathFactory");
     m_aXPathFactory = aXPathFactory;
-    m_aXPathVariableResolver = aXPathVariableResolver;
+    // Wrap the configured variable resolver in the one we use to resolved <let> variables
+    m_aXPathVariableResolver = new LetVariableResolver (aXPathVariableResolver);
     m_aXPathFunctionResolver = aXPathFunctionResolver;
   }
 

--- a/ph-schematron-pure/src/main/java/com/helger/schematron/pure/xpath/XPathEvaluationHelper.java
+++ b/ph-schematron-pure/src/main/java/com/helger/schematron/pure/xpath/XPathEvaluationHelper.java
@@ -82,6 +82,14 @@ public final class XPathEvaluationHelper
   }
 
   @Nullable
+  public static Double evaluateAsNumber (@Nonnull final XPathExpression aXPath,
+                                         @Nonnull final Node aItem,
+                                         @Nullable final String sBaseURI) throws XPathExpressionException
+  {
+    return evaluate (aXPath, aItem, XPathConstants.NUMBER, sBaseURI);
+  }
+
+  @Nullable
   public static String evaluateAsString (@Nonnull final XPathExpression aXPath,
                                          @Nonnull final Node aItem,
                                          @Nullable final String sBaseURI) throws XPathExpressionException

--- a/ph-schematron-pure/src/test/java/com/helger/schematron/pure/supplementary/Issue088Test.java
+++ b/ph-schematron-pure/src/test/java/com/helger/schematron/pure/supplementary/Issue088Test.java
@@ -17,7 +17,7 @@
 package com.helger.schematron.pure.supplementary;
 
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 
@@ -53,7 +53,7 @@ public final class Issue088Test
     if (false)
       LOGGER.info ("SVRL:\n" + sSVRL);
 
-    assertTrue (SVRLHelper.getAllFailedAssertionsAndSuccessfulReports (aSVRL).isEmpty ());
+    assertEquals (1, SVRLHelper.getAllFailedAssertionsAndSuccessfulReports (aSVRL).size ());
   }
 
   @Test

--- a/ph-schematron-pure/src/test/java/com/helger/schematron/pure/supplementary/Issue143Test.java
+++ b/ph-schematron-pure/src/test/java/com/helger/schematron/pure/supplementary/Issue143Test.java
@@ -23,7 +23,6 @@ import java.io.File;
 
 import javax.annotation.Nonnull;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,12 +49,10 @@ public final class Issue143Test
     if (true)
       LOGGER.info (new SVRLMarshaller ().getAsString (aSVRL));
 
-    // XXX Should be 1 but is currently 0
     assertEquals (1, SVRLHelper.getAllFailedAssertionsAndSuccessfulReports (aSVRL).size ());
   }
 
   @Test
-  @Ignore
   public void testIssue () throws Exception
   {
     validateAndProduceSVRL (new File ("src/test/resources/external/issues/github143/schematron.sch"),


### PR DESCRIPTION
Make the evaluation of variables declared in <let> more consistent with the Schematron ISO spec and other implementation.

During bind(), store the variables as members of the bound item they are defined in: schema, pattern and rule. The variables declared in a phase are stored in the schema, as it is already bound to the phase. Each set of variables is stored as map of name to compiled XPath expression.

During validate(), for each item we evaluate the corresponding variables in the appropriate context, and store the result in a LetVariableResolver instance.
This instance is set as the XPathVariableResolver, so a variable value will be resolved when executing an XPath that references the variable.

This fixes issue #143, so enable the corresponding unit test. This also resolves issue #88, so fix the corresponding unit test, as it was checking for the current behaviour, which is not correct.

**Note**

- The way the type of the variable value is handled in `_evaluateVariables` is not really nice, it just tries each possibility. Suggestions on how to improve this are welcome !
- I haven't looked into _validateParallel(), so there are probably changes required there to align it with _validateSerial()
- I've tried to follow the coding style guidelines, but I've probably missed some things. Feel free to correct them (or any other problem you see).