### PR TITLE
pure: Evaluate variables in the order they are declared

### DIFF
--- a/ph-schematron-pure/src/main/java/com/helger/schematron/pure/binding/xpath/IPSXPathVariables.java
+++ b/ph-schematron-pure/src/main/java/com/helger/schematron/pure/binding/xpath/IPSXPathVariables.java
@@ -23,8 +23,8 @@ import javax.annotation.Nullable;
 import javax.xml.xpath.XPathExpression;
 
 import com.helger.commons.annotation.ReturnsMutableCopy;
-import com.helger.commons.collection.impl.ICommonsNavigableMap;
-import com.helger.commons.collection.impl.ICommonsSortedSet;
+import com.helger.commons.collection.impl.ICommonsMap;
+import com.helger.commons.collection.impl.ICommonsSet;
 import com.helger.commons.lang.ICloneable;
 
 /**
@@ -39,7 +39,7 @@ public interface IPSXPathVariables extends ICloneable <PSXPathVariables>, Serial
    */
   @Nonnull
   @ReturnsMutableCopy
-  ICommonsNavigableMap <String, XPathExpression> getAll ();
+  ICommonsMap <String, XPathExpression> getAll ();
 
   /**
    * @return All contained variable names. Never <code>null</code>.
@@ -47,7 +47,7 @@ public interface IPSXPathVariables extends ICloneable <PSXPathVariables>, Serial
    */
   @Nonnull
   @ReturnsMutableCopy
-  ICommonsSortedSet <String> getAllNames ();
+  ICommonsSet <String> getAllNames ();
 
   /**
    * @param sName

--- a/ph-schematron-pure/src/main/java/com/helger/schematron/pure/binding/xpath/PSXPathVariables.java
+++ b/ph-schematron-pure/src/main/java/com/helger/schematron/pure/binding/xpath/PSXPathVariables.java
@@ -26,10 +26,9 @@ import javax.xml.xpath.XPathExpression;
 import com.helger.commons.ValueEnforcer;
 import com.helger.commons.annotation.Nonempty;
 import com.helger.commons.annotation.ReturnsMutableCopy;
-import com.helger.commons.collection.impl.CommonsTreeMap;
-import com.helger.commons.collection.impl.ICommonsNavigableMap;
-import com.helger.commons.collection.impl.ICommonsSortedSet;
-import com.helger.commons.compare.IComparator;
+import com.helger.commons.collection.impl.CommonsLinkedHashMap;
+import com.helger.commons.collection.impl.ICommonsMap;
+import com.helger.commons.collection.impl.ICommonsSet;
 import com.helger.commons.state.EChange;
 import com.helger.commons.string.StringHelper;
 import com.helger.commons.string.ToStringGenerator;
@@ -44,12 +43,12 @@ public class PSXPathVariables implements IPSXPathVariables
 {
   @Nonnull
   @ReturnsMutableCopy
-  private static ICommonsNavigableMap <String, XPathExpression> _createMap ()
+  private static ICommonsMap <String, XPathExpression> _createMap ()
   {
-    return new CommonsTreeMap <> (IComparator.getComparatorStringLongestFirst ());
+    return new CommonsLinkedHashMap <> ();
   }
 
-  private final ICommonsNavigableMap <String, XPathExpression> m_aMap;
+  private final ICommonsMap <String, XPathExpression> m_aMap;
 
   public PSXPathVariables ()
   {
@@ -138,14 +137,14 @@ public class PSXPathVariables implements IPSXPathVariables
 
   @Nonnull
   @ReturnsMutableCopy
-  public ICommonsNavigableMap <String, XPathExpression> getAll ()
+  public ICommonsMap <String, XPathExpression> getAll ()
   {
     return m_aMap.getClone ();
   }
 
   @Nonnull
   @ReturnsMutableCopy
-  public ICommonsSortedSet <String> getAllNames ()
+  public ICommonsSet <String> getAllNames ()
   {
     return m_aMap.copyOfKeySet ();
   }

--- a/ph-schematron-pure/src/test/java/com/helger/schematron/pure/supplementary/Issue177Test.java
+++ b/ph-schematron-pure/src/test/java/com/helger/schematron/pure/supplementary/Issue177Test.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2014-2024 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.schematron.pure.supplementary;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.File;
+
+import javax.annotation.Nonnull;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.helger.commons.io.resource.FileSystemResource;
+import com.helger.schematron.pure.SchematronResourcePure;
+import com.helger.schematron.pure.errorhandler.LoggingPSErrorHandler;
+import com.helger.schematron.svrl.SVRLHelper;
+import com.helger.schematron.svrl.SVRLMarshaller;
+import com.helger.schematron.svrl.jaxb.SchematronOutputType;
+
+public final class Issue177Test
+{
+  private static final Logger LOGGER = LoggerFactory.getLogger (Issue177Test.class);
+
+  public static void validateAndProduceSVRL (@Nonnull final File aSchematron, final File aXML) throws Exception
+  {
+    final SchematronResourcePure aSCH = SchematronResourcePure.fromFile (aSchematron);
+    aSCH.validateCompletely (new LoggingPSErrorHandler ());
+
+    // Perform validation
+    final SchematronOutputType aSVRL = aSCH.applySchematronValidationToSVRL (new FileSystemResource (aXML));
+    assertNotNull (aSVRL);
+    if (true)
+      LOGGER.info (new SVRLMarshaller ().getAsString (aSVRL));
+
+    assertEquals (0, SVRLHelper.getAllFailedAssertionsAndSuccessfulReports (aSVRL).size ());
+  }
+
+  @Test
+  public void testIssue () throws Exception
+  {
+    validateAndProduceSVRL (new File ("src/test/resources/external/issues/github177/schematron.sch"),
+                            new File ("src/test/resources/external/issues/github177/test.xml"));
+  }
+}

--- a/ph-schematron-pure/src/test/resources/external/issues/github177/schematron.sch
+++ b/ph-schematron-pure/src/test/resources/external/issues/github177/schematron.sch
@@ -1,0 +1,10 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xpath2">
+  <pattern>
+    <let name="var" value="1"/>
+    <let name="var-plus-one" value="$var + 1"/>
+
+    <rule context="/a">
+      <assert role="ERROR" test="$var-plus-one = 2">error message</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/ph-schematron-pure/src/test/resources/external/issues/github177/test.xml
+++ b/ph-schematron-pure/src/test/resources/external/issues/github177/test.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<a>
+  <b>
+    <c>1</c>
+  </b>
+  <b>
+    <c>2</c>
+  </b>
+  <b>
+    <c>3</c>
+  </b>
+</a>


### PR DESCRIPTION
Store the variables from the Schematron in a linked hashmap, to preserve their order. They are then evaluated in the order they are declared.

Before this, variables were sorted with the longest first. We were replacing variable references with their expressions, so starting with the longest was needed. With the new way of evaluating variables, this caused problems when a variable referenced another variable that has a shorter name.

This changes the IPSXPathVariables interface to return maps and sets, instead of navigable maps and sorted sets. It does not seem that the specifics of these types were used.

Add unit test that checks the correction of this bug.

Fixes #177.