### PR TITLE
Fix variable values thread safety in pure mode

### DIFF
--- a/ph-schematron-pure/src/main/java/com/helger/schematron/pure/xpath/XPathLetVariableResolver.java
+++ b/ph-schematron-pure/src/main/java/com/helger/schematron/pure/xpath/XPathLetVariableResolver.java
@@ -30,7 +30,14 @@ import com.helger.commons.string.ToStringGenerator;
 @NotThreadSafe
 public class XPathLetVariableResolver implements XPathVariableResolver
 {
-  private final ICommonsMap <QName, Object> m_aVariables = new CommonsHashMap <> ();
+  private final ThreadLocal<ICommonsMap <QName, Object>> m_aVariables = new ThreadLocal<> () {
+    @Override
+    protected ICommonsMap <QName, Object> initialValue()
+    {
+      return new CommonsHashMap <> ();
+    }
+  };
+
   private final XPathVariableResolver m_aDelegatedResolver;
 
   public XPathLetVariableResolver (@Nullable final XPathVariableResolver aResolver)
@@ -41,7 +48,7 @@ public class XPathLetVariableResolver implements XPathVariableResolver
   public void setVariableValue (@Nonnull final QName aVariableName, @Nullable final Object aValue)
   {
     ValueEnforcer.notNull (aVariableName, "VariableName");
-    m_aVariables.put (aVariableName, aValue);
+    m_aVariables.get().put (aVariableName, aValue);
   }
 
   /**
@@ -53,7 +60,7 @@ public class XPathLetVariableResolver implements XPathVariableResolver
   public void removeVariable (@Nullable final QName aVariableName)
   {
     if (aVariableName != null)
-      m_aVariables.remove (aVariableName);
+      m_aVariables.get().remove (aVariableName);
   }
 
   @Override
@@ -62,7 +69,7 @@ public class XPathLetVariableResolver implements XPathVariableResolver
     if (aVariableName != null)
     {
       // 1. variables
-      final Object result = m_aVariables.get (aVariableName);
+      final Object result = m_aVariables.get().get (aVariableName);
       if (result != null)
         return result;
 

--- a/ph-schematron-pure/src/test/java/com/helger/schematron/pure/supplementary/Issue182Test.java
+++ b/ph-schematron-pure/src/test/java/com/helger/schematron/pure/supplementary/Issue182Test.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2014-2024 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.schematron.pure.supplementary;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.File;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.helger.commons.io.resource.FileSystemResource;
+import com.helger.schematron.pure.SchematronResourcePure;
+import com.helger.schematron.pure.errorhandler.LoggingPSErrorHandler;
+import com.helger.schematron.svrl.SVRLHelper;
+import com.helger.schematron.svrl.SVRLMarshaller;
+import com.helger.schematron.svrl.jaxb.SchematronOutputType;
+
+/**
+ * Test for GitHub issue 182
+ *
+ * @author Bertrand Lorentz
+ */
+public final class Issue182Test
+{
+  private static final Logger LOGGER = LoggerFactory.getLogger (Issue182Test.class);
+
+  private static final String SCH = "src/test/resources/external/issues/github182/schematron.sch";
+  private static final String XML_A = "src/test/resources/external/issues/github182/testA.xml";
+  private static final String XML_B = "src/test/resources/external/issues/github182/testB.xml";
+
+  private SchematronResourcePure m_aSCH;
+
+  final private AtomicInteger errorCount = new AtomicInteger(0);
+
+  @Before
+  public void loadSchematron()
+  {
+    if (m_aSCH == null)
+      m_aSCH = SchematronResourcePure.fromFile (SCH);
+  }
+
+  public void validateAndProduceSVRL (final File aXML) throws Exception
+  {
+    m_aSCH.validateCompletely (new LoggingPSErrorHandler ());
+
+    // Perform validation
+    final SchematronOutputType aSVRL = m_aSCH.applySchematronValidationToSVRL (new FileSystemResource (aXML));
+    assertNotNull (aSVRL);
+    if (true)
+      LOGGER.info (aXML.getName() + " " + new SVRLMarshaller ().getAsString (aSVRL));
+
+    if (SVRLHelper.getAllFailedAssertionsAndSuccessfulReports (aSVRL).size () != 0)
+      errorCount.incrementAndGet();
+  }
+
+  @Test
+  public void testConcurrency () throws Exception
+  {
+    int numberOfThreads = 2;
+    ExecutorService service = Executors.newFixedThreadPool (10);
+    CountDownLatch startLatch = new CountDownLatch (1);
+    CountDownLatch finishedLatch = new CountDownLatch (numberOfThreads);
+    for (int i = 0; i < numberOfThreads; i += 2) {
+      service.execute (() -> {
+        try
+        {
+          startLatch.await ();
+          validateAndProduceSVRL (new File (XML_A));
+        }
+        catch (Exception e)
+        {
+          LOGGER.error ("Error validating XML A", e);
+        }
+        finishedLatch.countDown ();
+      });
+      service.execute(() -> {
+        try
+        {
+          startLatch.await ();
+          validateAndProduceSVRL (new File (XML_B));
+        }
+        catch (Exception e)
+        {
+          LOGGER.error ("Error validating XML B", e);
+        }
+        finishedLatch.countDown ();
+      });
+    }
+    // All threads are waiting on startLatch, release them all together
+    startLatch.countDown ();
+    // Wait until all threads are finished
+    finishedLatch.await ();
+
+    assertEquals (0, errorCount.get());
+  }
+}

--- a/ph-schematron-pure/src/test/resources/external/issues/github182/schematron.sch
+++ b/ph-schematron-pure/src/test/resources/external/issues/github182/schematron.sch
@@ -1,0 +1,11 @@
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xpath2">
+  <let name="var" value="/a/var/text()"/>
+  <pattern>
+    <rule context="/a/b/c[$var = 'A']">
+      <assert role="ERROR" test=". = $var">error message 1</assert>
+    </rule>
+    <rule context="/a/b/c[$var = 'B']">
+      <assert role="ERROR" test=". = $var">error message 1</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/ph-schematron-pure/src/test/resources/external/issues/github182/testA.xml
+++ b/ph-schematron-pure/src/test/resources/external/issues/github182/testA.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<a>
+  <var>A</var>
+  <b>
+    <c>A</c>
+  </b>
+  <b>
+    <c>A</c>
+  </b>
+  <b>
+    <c>A</c>
+  </b>
+</a>

--- a/ph-schematron-pure/src/test/resources/external/issues/github182/testB.xml
+++ b/ph-schematron-pure/src/test/resources/external/issues/github182/testB.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<a>
+  <var>B</var>
+  <b>
+    <c>B</c>
+  </b>
+  <b>
+    <c>B</c>
+  </b>
+  <b>
+    <c>B</c>
+  </b>
+</a>


### PR DESCRIPTION
Fix issue #182 by storing variable values in a ThreadLocal map, and add a unit test to check for this.

This might not be a perfect fix, but it seems to do the trick.

After this change, the compiled XPaths for the variable values are still potentially used from multiple threads, and [XPathExpression is indicated as not being thread-safe](https://docs.oracle.com/en/java/javase/11/docs/api/java.xml/javax/xml/xpath/XPathExpression.html).
But I did not see any easy way to adress this, and this does not seem to cause any problems.
